### PR TITLE
Fixed Animation Issues on FE

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -121,7 +121,7 @@ async function fetchCompanyDataStreaming(domain: string, _tabId?: number, forceU
             content: "You are a precise data extraction assistant that only provides verified company funding information. Always respond in the exact format requested, with no additional text or explanations. Ensure all data is accurate and complete before including it."
           }, {
             role: "user",
-            content: `Extract and provide verified funding information for ${companyName} using this exact format:
+            content: `Extract and provide verified funding information for the company ${companyName} using this exact format:
 
             COMPANY_NAME: [full legal company name - do not abbreviate, must be complete]
             TOTAL_FUNDING: [exact total funding amount with currency symbol, e.g. $100M, $1.2B]

--- a/src/chrome-extension/popup/index.tsx
+++ b/src/chrome-extension/popup/index.tsx
@@ -12,6 +12,7 @@ export const Popup = () => {
   const [isComplete, setIsComplete] = useState<boolean>(false);
   const [isCachedData, setIsCachedData] = useState<boolean>(false);
 
+
   useEffect(() => {
     console.log('Initializing Popup component');
     const chromeAPI = getChromeAPI();
@@ -118,6 +119,7 @@ export const Popup = () => {
 
   const handleSearch = async () => {
     // Reset states
+    setReceiptData({});
     setIsComplete(false);
     setIsCachedData(false);
     
@@ -126,6 +128,7 @@ export const Popup = () => {
     if (tab?.url) {
       const url = new URL(tab.url);
       const domain = url.hostname;
+      console.log('Forcing update for domain:', domain);
       chromeAPI.runtime.sendMessage(
         { 
           type: 'FETCH_COMPANY_DATA', 

--- a/src/components/Receipt.tsx
+++ b/src/components/Receipt.tsx
@@ -213,52 +213,15 @@ export const Receipt = ({
     // If we're loading and have data, animate in real-time
     if (loading) {
       setIsPrinting(true);
-      
-      // Only show sections that have data
       setVisibleSections(availableSections);
-
-      // If we have all sections, complete the animation
-      if (availableSections.length === 6) {
-        setTimeout(() => {
-          setIsPrinting(false);
-          setIsComplete(true);
-        }, 500);
-      }
       return;
     }
 
-    // If we're not loading and have no sections visible yet,
-    // start fresh with sequential animation
-    if (!loading && visibleSections.length === 0 && data.name) {
-      setIsPrinting(true);
-      setVisibleSections(["name"]);
-
-      const revealSection = (section: string, delay: number) => {
-        setTimeout(() => {
-          setVisibleSections((prev) => {
-            // Only add the section if we have data for it
-            if (availableSections.includes(section)) {
-              return [...prev, section];
-            }
-            return prev;
-          });
-
-          // Check if this is the last available section
-          if (section === availableSections[availableSections.length - 1]) {
-            setTimeout(() => {
-              setIsPrinting(false);
-              setIsComplete(true);
-            }, 500);
-          }
-        }, delay);
-      };
-
-      // Only schedule animations for sections that have data
-      if (data.totalFunding) revealSection("totalFunding", animationSpeed);
-      if (data.recentRound) revealSection("recentRound", animationSpeed * 2);
-      if (data.notableInvestors?.length) revealSection("notableInvestors", animationSpeed * 3);
-      if (data.sources?.length) revealSection("sources", animationSpeed * 4);
-      if (onSearch) revealSection("searchButton", animationSpeed * 5);
+    // If loading is false and we have received the complete message,
+    // stop the printing animation and show the result
+    if (!loading && data.name) {
+      setIsPrinting(false);
+      setIsComplete(true);
     }
   }, [data, loading, animationSpeed, skipAnimation, onSearch]);
 


### PR DESCRIPTION
1. Certain edge cases like Linear were causing the Perplexity API to not return certain sections which would let the Printing animation run on forever. Fixed this issue.
2. When clicking the "Print Fresh Data" button the receiptData would still show the previous data so it was hard to tell that the data was actually being refreshed. Added setReceiptData({}); to handleSearch to fix this.